### PR TITLE
Adding an optional "out" argument to the generate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guestlinelabs/onekey",
-  "version": "0.0.14",
+  "version": "0.1.0",
   "description": "Utility to download translations from the [OneSky](https://www.oneskyapp.com/) and generate typed keys in Typescript for having typed translations.",
   "bin": {
     "onekey": "lib/cli.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,7 @@ const GenerateArguments = t.intersection([
   strictPartial({
     prettier: t.string,
     locale: t.string,
+    out: t.string,
   }),
 ]);
 type GenerateArguments = t.TypeOf<typeof GenerateArguments>;
@@ -181,6 +182,12 @@ const yarg = yargs(process.argv.slice(2))
           alias: 'i',
           describe: 'Path for the json translations',
         },
+        out: {
+          type: 'string',
+          demandOption: true,
+          alias: 'o',
+          describe: 'Where to save the translation keys',
+        },
         prettier: {
           type: 'string',
           alias: 'c',
@@ -222,6 +229,7 @@ const program = pipe(
               defaultLocale: operation.args.locale || 'en-GB',
               prettierConfigPath: operation.args.prettier,
               translationsPath: operation.args.input,
+              translationKeysPath: operation.args.out || operation.args.input,
             });
             break;
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,7 +184,6 @@ const yarg = yargs(process.argv.slice(2))
         },
         out: {
           type: 'string',
-          demandOption: true,
           alias: 'o',
           describe: 'Where to save the translation keys',
         },

--- a/src/file.ts
+++ b/src/file.ts
@@ -159,16 +159,18 @@ function readTranslations(config: {
 
 export function saveKeys({
   translationsPath,
+  translationKeysPath,
   defaultLocale = 'en-GB',
   prettierConfigPath,
 }: {
   translationsPath: string;
+  translationKeysPath: string;
   defaultLocale: string;
   prettierConfigPath?: string;
 }): TE.TaskEither<Error, void> {
   const languagesPath = path.resolve(translationsPath, 'languages.json');
   const translationsLocalePath = path.resolve(translationsPath, defaultLocale);
-  const outPath = path.resolve(translationsPath, 'translation.ts');
+  const outPath = path.resolve(translationKeysPath, 'translation.ts');
 
   const content = Do.Do(TE.taskEither)
     .bind('fileNames', readdir(translationsLocalePath))


### PR DESCRIPTION
Adding an optional "out" argument to the generate command so we don't have to save the `.ts` file in same folder as we save the translations