### PR TITLE
Added a retry mechanism for fetching single file from OneSky

### DIFF
--- a/src/fetch-translations.ts
+++ b/src/fetch-translations.ts
@@ -1,6 +1,24 @@
 import { z } from 'zod';
 import * as onesky from './onesky';
 
+// From: https://stackoverflow.com/questions/38213668/promise-retry-design-patterns
+const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+const retryOperation = (operation: () => Promise<TranslationFile>, delay: number, retries: number): Promise<TranslationFile> => new Promise((resolve, reject) => {
+  return operation()
+    .then(resolve)
+    .catch((reason) => {
+      if (retries > 0) {
+        console.log("Attempting to retry fetching translations")
+        return wait(delay)
+          .then(retryOperation.bind(null, operation, delay, retries - 1))
+          .then(resolve)
+          .catch(reject);
+      }
+      return reject(reason);
+    });
+});
+
 const mapKeys = <A>(
   f: (key: string) => string,
   r: Record<string, A>
@@ -93,13 +111,14 @@ async function getFile({
 }): Promise<{
   [languageCode: string]: TranslationSchema;
 }> {
-  const file = await onesky.getFile({
+
+  const file = await retryOperation(() => onesky.getFile({
     apiKey,
     fileName,
     projectId,
     secret,
     languages,
-  });
+  }), 5000, 3)
 
   return mapKeys(getLanguageCode, file);
 }


### PR DESCRIPTION
I added a retry mechanism so that when OneSky responds with a 504, we can continue trying. That response does happen from time to time, but I was not able to reproduce it locally. It would always return a file and not timed out. I have checked that the change is not affecting the fetching file process. However, based on the code, if an error occurs or the response is not valid, we throw an error and that should be picked up with a retry mechanism.

I looked into how we can add a test for it, but it seems that mocking two calls to give a different response is not possible with `nock` - https://github.com/nock/nock/issues/803.
