### PR TITLE
Support plularization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guestlinelabs/onekey",
-	"version": "5.0.4",
+	"version": "5.0.3",
 	"description": "Local translation management utility with AI translation support and TypeScript key generation",
 	"bin": {
 		"onekey": "lib/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@guestlinelabs/onekey",
-	"version": "5.0.3",
+	"version": "5.0.4",
 	"description": "Local translation management utility with AI translation support and TypeScript key generation",
 	"bin": {
 		"onekey": "lib/cli.js"

--- a/src/generate-translation-keys.ts
+++ b/src/generate-translation-keys.ts
@@ -23,6 +23,24 @@ function transformKeys<T extends Record<string, unknown>>(
 	return transformed as T;
 }
 
+function isPluralKey(key: string, parameters: string[]): boolean {
+	const pluralSuffixes = ["_zero", "_one", "_two", "_few", "_many", "_other"];
+	return (
+		pluralSuffixes.some((suffix) => key.endsWith(suffix)) &&
+		parameters.includes("count")
+	);
+}
+
+function getBasePluralKey(key: string): string {
+	const pluralSuffixes = ["_zero", "_one", "_two", "_few", "_many", "_other"];
+	for (const suffix of pluralSuffixes) {
+		if (key.endsWith(suffix)) {
+			return key.slice(0, -suffix.length);
+		}
+	}
+	return key;
+}
+
 function getFileKeys(
 	translations: TranslationSchema,
 ): Record<string, string[]> {
@@ -120,7 +138,33 @@ export async function generateKeys({
 				...cur,
 			};
 		}, {});
-	const { parameterized, simple } = Object.entries(allKeys).reduce(
+
+	// Identify plural keys and convert them to base keys
+	const pluralBaseKeys = new Map<string, string[]>();
+	for (const key of Object.keys(allKeys)) {
+		const [namespace, ...rest] = key.split(":");
+		const translationKey = rest.join(":");
+		if (isPluralKey(translationKey, allKeys[key])) {
+			const baseKey = getBasePluralKey(translationKey);
+			const fullBaseKey = `${namespace}:${baseKey}`;
+			// Store the parameters from the first plural form we encounter
+			if (!pluralBaseKeys.has(fullBaseKey)) {
+				pluralBaseKeys.set(fullBaseKey, allKeys[key]);
+			}
+		}
+	}
+
+	// Add base keys for plural forms with their parameters
+	const allKeysWithPluralBases = { ...allKeys };
+	for (const [baseKey, parameters] of pluralBaseKeys.entries()) {
+		if (!allKeysWithPluralBases[baseKey]) {
+			allKeysWithPluralBases[baseKey] = parameters;
+		}
+	}
+
+	const { parameterized, simple } = Object.entries(
+		allKeysWithPluralBases,
+	).reduce(
 		(acc, [key, parameters]) => {
 			if (parameters.length > 0) {
 				return {

--- a/test/generate-translation-keys.test.ts
+++ b/test/generate-translation-keys.test.ts
@@ -278,4 +278,273 @@ describe("generate-translation-keys", () => {
 		expect(source).toContain('"main:hello": { name: string }');
 		expect(source).toContain('"main:welcome": { user: string; place: string }');
 	});
+
+	describe("plural keys", () => {
+		it("should handle basic plural forms with count parameter", async () => {
+			const pluralTranslations: Translations = {
+				main: {
+					items_one: "You have {{count}} item",
+					items_other: "You have {{count}} items",
+				},
+			};
+
+			const source = await generateKeys({
+				translations: pluralTranslations,
+				languages,
+				prettierConfig: {},
+				defaultLocale: "en-GB",
+			});
+
+			// Should generate base key with same parameters as plural forms
+			expect(source).toContain('"main:items": { count: number }');
+			// Should keep the suffixed versions in parameterized keys
+			expect(source).toContain('"main:items_one": { count: number }');
+			expect(source).toContain('"main:items_other": { count: number }');
+			// All plural keys should be in TranslationWithOptions
+			expect(source).toContain(
+				"export type TranslationKeyWithoutOptions = never",
+			);
+		});
+
+		it("should handle all plural form suffixes", async () => {
+			const pluralTranslations: Translations = {
+				main: {
+					items_zero: "No items",
+					items_one: "{{count}} item",
+					items_two: "{{count}} items",
+					items_few: "{{count}} items",
+					items_many: "{{count}} items",
+					items_other: "{{count}} items",
+				},
+			};
+
+			const source = await generateKeys({
+				translations: pluralTranslations,
+				languages,
+				prettierConfig: {},
+				defaultLocale: "en-GB",
+			});
+
+			// Should generate the base key with parameters
+			expect(source).toContain('"main:items": { count: number }');
+			// Should keep the suffixed versions with count parameter
+			expect(source).toContain('"main:items_zero"');
+			expect(source).toContain('"main:items_one": { count: number }');
+			expect(source).toContain('"main:items_two": { count: number }');
+			expect(source).toContain('"main:items_few": { count: number }');
+			expect(source).toContain('"main:items_many": { count: number }');
+			expect(source).toContain('"main:items_other": { count: number }');
+		});
+
+		it("should handle nested plural keys", async () => {
+			const nestedPluralTranslations: Translations = {
+				main: {
+					user: {
+						messages_one: "{{count}} message",
+						messages_other: "{{count}} messages",
+					},
+				},
+			};
+
+			const source = await generateKeys({
+				translations: nestedPluralTranslations,
+				languages,
+				prettierConfig: {},
+				defaultLocale: "en-GB",
+			});
+
+			// Should generate the base key with parameters
+			expect(source).toContain('"main:user.messages": { count: number }');
+			// Should keep the suffixed versions with count parameter
+			expect(source).toContain('"main:user.messages_one": { count: number }');
+			expect(source).toContain('"main:user.messages_other": { count: number }');
+			// All keys should be parameterized
+			expect(source).toContain(
+				"export type TranslationKeyWithoutOptions = never",
+			);
+		});
+
+		it("should not treat keys with plural suffixes as plural without count parameter", async () => {
+			const nonPluralTranslations: Translations = {
+				main: {
+					items_one: "First item",
+					items_other: "Other items",
+				},
+			};
+
+			const source = await generateKeys({
+				translations: nonPluralTranslations,
+				languages,
+				prettierConfig: {},
+				defaultLocale: "en-GB",
+			});
+
+			// Without count parameter, these should be treated as regular keys
+			expect(source).toContain('"main:items_one"');
+			expect(source).toContain('"main:items_other"');
+		});
+
+		it("should handle mixed plural and non-plural keys", async () => {
+			const mixedTranslations: Translations = {
+				main: {
+					hello: "Hello",
+					items_one: "{{count}} item",
+					items_other: "{{count}} items",
+					goodbye: "Goodbye",
+					messages_one: "{{count}} message",
+					messages_other: "{{count}} messages",
+				},
+			};
+
+			const source = await generateKeys({
+				translations: mixedTranslations,
+				languages,
+				prettierConfig: {},
+				defaultLocale: "en-GB",
+			});
+
+			// Should contain simple non-plural keys in TranslationKeyWithoutOptions
+			expect(source).toContain('"main:hello"');
+			expect(source).toContain('"main:goodbye"');
+			expect(source).toContain(
+				'export type TranslationKeyWithoutOptions = "main:hello" | "main:goodbye"',
+			);
+			// Should have plural base keys with parameters
+			expect(source).toContain('"main:items": { count: number }');
+			expect(source).toContain('"main:messages": { count: number }');
+			// Should keep the suffixed plural versions with count parameter
+			expect(source).toContain('"main:items_one": { count: number }');
+			expect(source).toContain('"main:items_other": { count: number }');
+			expect(source).toContain('"main:messages_one": { count: number }');
+			expect(source).toContain('"main:messages_other": { count: number }');
+		});
+
+		it("should handle plural keys with additional parameters", async () => {
+			const pluralWithParamsTranslations: Translations = {
+				main: {
+					items_one: "{{name}} has {{count}} item",
+					items_other: "{{name}} has {{count}} items",
+				},
+			};
+
+			const source = await generateKeys({
+				translations: pluralWithParamsTranslations,
+				languages,
+				prettierConfig: {},
+				defaultLocale: "en-GB",
+			});
+
+			// Should generate the base key with same parameters as plural forms
+			expect(source).toContain('"main:items": { name: string; count: number }');
+			// Should include both count and name parameters in the suffixed versions
+			expect(source).toContain(
+				'"main:items_one": { name: string; count: number }',
+			);
+			expect(source).toContain(
+				'"main:items_other": { name: string; count: number }',
+			);
+			// All keys should be parameterized
+			expect(source).toContain(
+				"export type TranslationKeyWithoutOptions = never",
+			);
+		});
+
+		it("should handle partial plural forms", async () => {
+			const partialPluralTranslations: Translations = {
+				main: {
+					items_one: "{{count}} item",
+					// Only _one form exists, not _other
+				},
+			};
+
+			const source = await generateKeys({
+				translations: partialPluralTranslations,
+				languages,
+				prettierConfig: {},
+				defaultLocale: "en-GB",
+			});
+
+			// Should generate the base key with parameters
+			expect(source).toContain('"main:items": { count: number }');
+			// Should keep the suffixed version with count parameter
+			expect(source).toContain('"main:items_one": { count: number }');
+			// All keys should be parameterized
+			expect(source).toContain(
+				"export type TranslationKeyWithoutOptions = never",
+			);
+		});
+
+		it("should handle deeply nested plural keys", async () => {
+			const deeplyNestedPlurals: Translations = {
+				main: {
+					user: {
+						profile: {
+							notifications_one: "{{count}} notification",
+							notifications_other: "{{count}} notifications",
+						},
+					},
+				},
+			};
+
+			const source = await generateKeys({
+				translations: deeplyNestedPlurals,
+				languages,
+				prettierConfig: {},
+				defaultLocale: "en-GB",
+			});
+
+			// Should generate the base key with parameters
+			expect(source).toContain(
+				'"main:user.profile.notifications": { count: number }',
+			);
+			// Should keep the suffixed versions with count parameter
+			expect(source).toContain(
+				'"main:user.profile.notifications_one": { count: number }',
+			);
+			expect(source).toContain(
+				'"main:user.profile.notifications_other": { count: number }',
+			);
+			// All keys should be parameterized
+			expect(source).toContain(
+				"export type TranslationKeyWithoutOptions = never",
+			);
+		});
+
+		it("should handle plural keys across multiple namespaces", async () => {
+			const multiNamespacePlurals: Translations = {
+				main: {
+					items_one: "{{count}} item",
+					items_other: "{{count}} items",
+				},
+				errors: {
+					validationErrors_one: "{{count}} error",
+					validationErrors_other: "{{count}} errors",
+				},
+			};
+
+			const source = await generateKeys({
+				translations: multiNamespacePlurals,
+				languages,
+				prettierConfig: {},
+				defaultLocale: "en-GB",
+			});
+
+			// Should generate base keys with parameters
+			expect(source).toContain('"main:items": { count: number }');
+			expect(source).toContain('"errors:validationErrors": { count: number }');
+			// Should keep the suffixed versions with count parameter
+			expect(source).toContain('"main:items_one": { count: number }');
+			expect(source).toContain('"main:items_other": { count: number }');
+			expect(source).toContain(
+				'"errors:validationErrors_one": { count: number }',
+			);
+			expect(source).toContain(
+				'"errors:validationErrors_other": { count: number }',
+			);
+			// All keys should be parameterized
+			expect(source).toContain(
+				"export type TranslationKeyWithoutOptions = never",
+			);
+		});
+	});
 });

--- a/test/generate-translation-keys.test.ts
+++ b/test/generate-translation-keys.test.ts
@@ -546,5 +546,38 @@ describe("generate-translation-keys", () => {
 				"export type TranslationKeyWithoutOptions = never",
 			);
 		});
+
+		it("should not generate duplicate keys when base key exists alongside plural forms", async () => {
+			const translationsWithBaseAndPluralKeys: Translations = {
+				main: {
+					items: "Items", // Base key without parameters
+					items_one: "{{count}} item",
+					items_other: "{{count}} items",
+				},
+			};
+
+			const source = await generateKeys({
+				translations: translationsWithBaseAndPluralKeys,
+				languages,
+				prettierConfig: {},
+				defaultLocale: "en-GB",
+			});
+
+			// Count how many times "main:items" appears in TranslationKeyWithOptions
+			const optionsTypeMatch = source.match(
+				/export type TranslationKeyWithOptions = {[^}]*}/s,
+			);
+			if (optionsTypeMatch) {
+				const optionsType = optionsTypeMatch[0];
+				const itemsMatches = optionsType.match(/"main:items":/g);
+				expect(itemsMatches?.length).toBe(1); // Should only appear once
+			}
+
+			// Should have "main:items" in TranslationKeyWithoutOptions since base key has no params
+			expect(source).toContain('"main:items"');
+			// Should have plural forms with count parameter in TranslationKeyWithOptions
+			expect(source).toContain('"main:items_one": { count: number }');
+			expect(source).toContain('"main:items_other": { count: number }');
+		});
 	});
 });


### PR DESCRIPTION
i18n supports pluralizations, allowing to have multiple variants for given translations with suffixes.

This PR adds the base key to the generated types.

For example, from i18n documentation this is allowed. But since the base 'key' is not defined, we would get type error if we tried to use this

<img width="825" height="589" alt="image" src="https://github.com/user-attachments/assets/9cf0e59d-9734-4917-814e-ad927853066d" />
